### PR TITLE
[BUGFIX] Adjust method signature of publishCollection to current Flow

### DIFF
--- a/Classes/Wwwision/PrivateResources/Resource/Target/ProtectedResourceTarget.php
+++ b/Classes/Wwwision/PrivateResources/Resource/Target/ProtectedResourceTarget.php
@@ -85,10 +85,10 @@ class ProtectedResourceTarget implements TargetInterface {
 	}
 
 	/**
-	 * @param Collection $collection The collection to publish
+	 * @param CollectionInterface $collection The collection to publish
 	 * @return void
 	 */
-	public function publishCollection(Collection $collection) {
+	public function publishCollection(CollectionInterface $collection) {
 		// publishing is not required for protected resources
 	}
 


### PR DESCRIPTION
The publishCollection method expects a CollectionInterface instead of a Collection in its signature.