### PR TITLE
[TASK] Send file name and file size in HTTP headers

### DIFF
--- a/Classes/Wwwision/PrivateResources/Http/Component/ProtectedResourceComponent.php
+++ b/Classes/Wwwision/PrivateResources/Http/Component/ProtectedResourceComponent.php
@@ -111,6 +111,8 @@ class ProtectedResourceComponent implements ComponentInterface {
 		}
 		$httpResponse = $componentContext->getHttpResponse();
 		$httpResponse->setHeader('Content-Type', $resource->getMediaType());
+		$httpResponse->setHeader('Content-Disposition', 'attachment;filename="' . $resource->getFilename() . '"');
+		$httpResponse->setHeader('Content-Length', $resource->getFileSize());
 
 		$this->emitResourceServed($resource, $httpRequest);
 


### PR DESCRIPTION
Since the URL serving the file contains only a hash, but not the file name, the file name and file size should be sent with the HTTP headers so the file can be saved with the name and extension it originally had.