### PR TITLE
Be less strict about flow version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "A Flow package that allows for protecting persistent resources from unauthorized access",
     "license": "MIT",
     "require": {
-        "neos/flow": "~4.1.0"
+        "neos/flow": "~4.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
As the API of Flow is very stable and cares about breaking changes, I think having a version constraint on the major version is definitely enough => 4.1.0 - 4.9.99