### PR TITLE
!!!FEATURE: Support cloud storage

### DIFF
--- a/Classes/Http/Component/ProtectedResourceComponent.php
+++ b/Classes/Http/Component/ProtectedResourceComponent.php
@@ -106,20 +106,6 @@ class ProtectedResourceComponent implements ComponentInterface
                 chr(10), $tokenData['resourceIdentifier']), 1429621743);
         }
 
-        // TODO there should be a better way to determine the absolute path of the resource? Resource::createTemporaryLocalCopy() is too expensive
-        $resourcePathAndFilename = Files::concatenatePaths([
-            $this->options['basePath'],
-            $tokenData['resourceIdentifier'][0],
-            $tokenData['resourceIdentifier'][1],
-            $tokenData['resourceIdentifier'][2],
-            $tokenData['resourceIdentifier'][3],
-            $tokenData['resourceIdentifier']
-        ]);
-        if (!is_file($resourcePathAndFilename)) {
-            throw new FileNotFoundException(sprintf('File not found!%sThe file "%s" does not exist', chr(10),
-                $resourcePathAndFilename), 1429702284);
-        }
-
         if (!isset($this->options['serveStrategy'])) {
             throw new FlowException('No "serveStrategy" configured!', 1429704107);
         }
@@ -136,7 +122,7 @@ class ProtectedResourceComponent implements ComponentInterface
 
         $this->emitResourceServed($resource, $httpRequest);
 
-        $fileServeStrategy->serve($resourcePathAndFilename, $httpResponse);
+        $fileServeStrategy->serve($resource, $httpResponse, $this->options);
         $componentContext->setParameter(ComponentChain::class, 'cancel', true);
     }
 

--- a/Classes/Http/FileServeStrategy/FileServeStrategyInterface.php
+++ b/Classes/Http/FileServeStrategy/FileServeStrategyInterface.php
@@ -6,6 +6,7 @@ namespace Wwwision\PrivateResources\Http\FileServeStrategy;
  *                                                                             */
 
 use Neos\Flow\Http\Response as HttpResponse;
+use Neos\Flow\ResourceManagement\PersistentResource;
 
 /**
  * Contract for a strategy that allows for serving files outside of the public folder structure
@@ -14,9 +15,10 @@ interface FileServeStrategyInterface
 {
 
     /**
-     * @param string $filePathAndName Absolute path to the file to serve
+     * @param PersistentResource $resource Resource of the file to serve
      * @param HttpResponse $httpResponse The current HTTP response (allows setting headers, ...)
+     * @param array $options
      * @return void
      */
-    public function serve($filePathAndName, HttpResponse $httpResponse);
+    public function serve(PersistentResource $resource, HttpResponse $httpResponse, $options);
 }

--- a/Classes/Http/FileServeStrategy/ReadfileStrategy.php
+++ b/Classes/Http/FileServeStrategy/ReadfileStrategy.php
@@ -7,6 +7,8 @@ namespace Wwwision\PrivateResources\Http\FileServeStrategy;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Http\Response as HttpResponse;
+use Neos\Flow\ResourceManagement\PersistentResource;
+use Wwwision\PrivateResources\Utility\ProtectedResourceUtility;
 
 /**
  * A file serve strategy that outputs the given file using PHPs readfile function
@@ -17,12 +19,14 @@ class ReadfileStrategy implements FileServeStrategyInterface
 {
 
     /**
-     * @param string $filePathAndName Absolute path to the file to serve
+     * @param PersistentResource $resource Absolute path to the file to serve
      * @param HttpResponse $httpResponse The current HTTP response (allows setting headers, ...)
      * @return void
      */
-    public function serve($filePathAndName, HttpResponse $httpResponse)
+    public function serve(PersistentResource $resource, HttpResponse $httpResponse, $options)
     {
+        $filePathAndName = ProtectedResourceUtility::getStoragePathAndFilenameByHash($resource->getSha1(), $options['basePath']);
+
         $httpResponse->sendHeaders();
         // Ensure no output buffer is used so the file contents won't be loaded into the RAM
         // BTW: This does not work with xdebug enabled! (any output will be buffered by xdebug)

--- a/Classes/Http/FileServeStrategy/StreamStrategy.php
+++ b/Classes/Http/FileServeStrategy/StreamStrategy.php
@@ -1,0 +1,40 @@
+<?php
+namespace Wwwision\PrivateResources\Http\FileServeStrategy;
+
+/*                                                                             *
+ * This script belongs to the Neos Flow package "Wwwision.PrivateResources".   *
+ *                                                                             */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Http\Response as HttpResponse;
+use Neos\Flow\ResourceManagement\PersistentResource;
+
+/**
+ * A file serve strategy that streams the given resource
+ *
+ * @Flow\Scope("singleton")
+ */
+class StreamStrategy implements FileServeStrategyInterface
+{
+
+    /**
+     * @param PersistentResource $resource Absolute path to the file to serve
+     * @param HttpResponse $httpResponse The current HTTP response (allows setting headers, ...)
+     * @return void
+     */
+    public function serve(PersistentResource $resource, HttpResponse $httpResponse, $options)
+    {
+        $httpResponse->sendHeaders();
+        // Ensure no output buffer is used so the file contents won't be loaded into the RAM
+        // BTW: This does not work with xdebug enabled! (any output will be buffered by xdebug)
+        while (ob_get_level() > 0) {
+            ob_end_flush();
+        }
+        $stream = $resource->getStream();
+        while ($buffer = fread($stream, 4096)) {
+            echo $buffer;
+        }
+        fclose($stream);
+        exit;
+    }
+}

--- a/Classes/Http/FileServeStrategy/XAccelRedirectStrategy.php
+++ b/Classes/Http/FileServeStrategy/XAccelRedirectStrategy.php
@@ -7,6 +7,8 @@ namespace Wwwision\PrivateResources\Http\FileServeStrategy;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Http\Response as HttpResponse;
+use Neos\Flow\ResourceManagement\PersistentResource;
+use Wwwision\PrivateResources\Utility\ProtectedResourceUtility;
 
 /**
  * A file serve strategy that uses the custom "X-accel-Redirect" header to let Nginx servers handle the file download.
@@ -20,12 +22,13 @@ class XAccelRedirectStrategy implements FileServeStrategyInterface
 {
 
     /**
-     * @param string $filePathAndName Absolute path to the file to serve
+     * @param PersistentResource $resource Absolute path to the file to serve
      * @param HttpResponse $httpResponse The current HTTP response (allows setting headers, ...)
      * @return void
      */
-    public function serve($filePathAndName, HttpResponse $httpResponse)
+    public function serve(PersistentResource $resource, HttpResponse $httpResponse, $options)
     {
+        $filePathAndName = ProtectedResourceUtility::getStoragePathAndFilenameByHash($resource->getSha1(), $options['basePath']);
         $httpResponse->setHeader('X-Accel-Redirect', $filePathAndName);
     }
 }

--- a/Classes/Http/FileServeStrategy/XSendfileStrategy.php
+++ b/Classes/Http/FileServeStrategy/XSendfileStrategy.php
@@ -7,6 +7,8 @@ namespace Wwwision\PrivateResources\Http\FileServeStrategy;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Http\Response as HttpResponse;
+use Neos\Flow\ResourceManagement\PersistentResource;
+use Wwwision\PrivateResources\Utility\ProtectedResourceUtility;
 
 /**
  * A file serve strategy that uses the custom "X-Sendfile" header to let Apache servers handle the file download.
@@ -19,12 +21,13 @@ class XSendfileStrategy implements FileServeStrategyInterface
 {
 
     /**
-     * @param string $filePathAndName Absolute path to the file to serve
+     * @param PersistentResource $resource Absolute path to the file to serve
      * @param HttpResponse $httpResponse The current HTTP response (allows setting headers, ...)
      * @return void
      */
-    public function serve($filePathAndName, HttpResponse $httpResponse)
+    public function serve(PersistentResource $resource, HttpResponse $httpResponse, $options)
     {
+        $filePathAndName = ProtectedResourceUtility::getStoragePathAndFilenameByHash($resource->getSha1(), $options['basePath']);
         $httpResponse->setHeader('X-Sendfile', $filePathAndName);
     }
 }

--- a/Classes/Utility/ProtectedResourceUtility.php
+++ b/Classes/Utility/ProtectedResourceUtility.php
@@ -1,0 +1,49 @@
+<?php
+namespace Wwwision\PrivateResources\Utility;
+
+/*                                                                             *
+ * This script belongs to the Neos Flow package "Wwwision.PrivateResources".   *
+ *                                                                             */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Utility\Files;
+use Wwwision\PrivateResources\Http\Component\Exception\FileNotFoundException;
+
+/**
+ * A HTTP Component that checks for the request argument "__protectedResource" and outputs the requested resource if the client tokens match
+ */
+class ProtectedResourceUtility
+{
+
+    /**
+     *
+     * @param string $sha1Hash
+     * @param string $basePath
+     * @return string
+     * @throws FileNotFoundException
+     */
+    public static function getStoragePathAndFilenameByHash($sha1Hash, $basePath)
+    {
+        // TODO there should be a better way to determine the absolute path of the resource? Resource::createTemporaryLocalCopy() is too expensive
+        $resourcePathAndFilename = Files::concatenatePaths(
+            [
+                $basePath,
+                $sha1Hash[0],
+                $sha1Hash[1],
+                $sha1Hash[2],
+                $sha1Hash[3],
+                $sha1Hash
+            ]
+        );
+        if (!is_file($resourcePathAndFilename)) {
+            throw new FileNotFoundException(
+                sprintf(
+                    'File not found!%sThe file "%s" does not exist',
+                    chr(10),
+                    $resourcePathAndFilename
+                ), 1429702284
+            );
+        }
+        return $resourcePathAndFilename;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ roles. However, resources will still be downloaded obviously and users can share
 Furthermore serving private resources consumes more time and memory because every hit triggers a PHP request.
 Conclusion: This package is only useful in very rare cases ;) 
 
+Version:
+--------
+
+The table below provides an overview of the available versions.
+
+Note: The releases version 3.4.0 is not compatible with Flow < 6.
+
+| Branch / Release   | Supported Flow version |
+| ------------------ | ---------------------- |
+| 3.x, 4.x           | 4.1, 5.x               |
+| 3.4, 5.x, master   | 6.x                    |
+
 How-To:
 -------
 

--- a/README.md
+++ b/README.md
@@ -148,9 +148,11 @@ routing kicks in.
 This ``ProtectedResourceComponent`` is already configured and if it comes across an HTTP requests with an
 "__protectedResource" argument it will validate the hash and output the requested file, if valid.
 
-By default it uses PHPs ``readfile()`` function to stream the file from its inaccessible location to the client, but
+By default it uses PHPs ``readfile()`` function to stream a local file from its inaccessible location to the client, but
 this has some drawbacks because it has to pipe the whole file through the PHP process consuming a lot of memory,
 especially for larger files.
+
+To support external cloud storage use the `StreamStrategy` described further below.
 
 To improve performance and memory footprint you can therefore configure the component to use different strategies to
 serve the file:
@@ -195,6 +197,26 @@ Neos:
             'protectedResources':
               componentOptions:
                 serveStrategy: 'Wwwision\PrivateResources\Http\FileServeStrategy\XAccelRedirectStrategy'
+```
+
+#### Stream ####
+
+This strategy uses the read-only stream offered by the ResourceManager. It should be compatible with all
+StorageInterfaces and supports external storage (e.g. AWS S3, Google Cloud Storage GCS). But this has some
+drawbacks because it has to pipe the whole file through the PHP process consuming a lot of memory and CPU time.
+
+It can be activated with:
+
+```yaml
+Neos:
+  Flow:
+    http:
+      chain:
+        'process':
+          chain:
+            'protectedResources':
+              componentOptions:
+                serveStrategy: 'Wwwision\PrivateResources\Http\FileServeStrategy\StreamStrategy'
 ```
 
 #### Custom strategy ####


### PR DESCRIPTION
Currently the `$filePathAndName` is used directly in the method `serve()`. This prevents the development of strategies to deliver files that are not identified by file names.
    
This breaking change replaces `$filePathAndName` with `$resource`. If a strategy is used to serve files from `FileSystemStorage` it can use the new static method `ProtectedResourceUtility:getStoragePathAndFilenameByHash()` to find the local file name.

Additionally this change introduces a `StreamStrategy` to stream resources from external storage (e.g. AWS S3, Google Cloud Storage GCS).

Related: #17