### PR TITLE
Task: allow neos 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Note: The releases version 3.4.0 is not compatible with Flow < 6.
 | ------------------ | ---------------------- |
 | 3.x, 4.x           | 4.1, 5.x               |
 | 3.4, 5.x           | 6.x                    |
-| 6.x, master        | 7.x                    |
+| 6.x, master        | 7.x, 8.x               |
 
 How-To:
 -------

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "A Flow package that allows for protecting persistent resources from unauthorized access",
     "license": "MIT",
     "require": {
-        "neos/flow": "^7.0",
+        "neos/flow": "^7.0 || ^8.0",
         "guzzlehttp/psr7": "^1.6"
     },
     "autoload": {


### PR DESCRIPTION
Allows installation on neos 8.0.

I manually tested it and it seems to work fine.