### PR TITLE
Add compatibility for Neos 8 and add correct authentication

### DIFF
--- a/Classes/Http/Middleware/ProtectedResourceMiddleware.php
+++ b/Classes/Http/Middleware/ProtectedResourceMiddleware.php
@@ -28,6 +28,8 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Wwwision\PrivateResources\Http\Middleware\Exception\FileNotFoundException;
 use Wwwision\PrivateResources\Http\FileServeStrategy\FileServeStrategyInterface;
+use Neos\Neos\Controller\Backend\BackendController;
+
 
 /**
  * A HTTP Middleware that checks for the request argument "__protectedResource" and outputs the requested resource if the client tokens match
@@ -163,6 +165,7 @@ class ProtectedResourceMiddleware implements MiddlewareInterface
             return;
         }
         $actionRequest = ActionRequest::fromHttpRequest($httpRequest);
+        $actionRequest->setControllerObjectName(BackendController::class);
         $this->securityContext->setRequest($actionRequest);
         if (isset($tokenData['privilegedRole'])) {
             if ($this->securityContext->hasRole($tokenData['privilegedRole'])) {

--- a/Classes/Http/Middleware/ProtectedResourceMiddleware.php
+++ b/Classes/Http/Middleware/ProtectedResourceMiddleware.php
@@ -28,7 +28,7 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Wwwision\PrivateResources\Http\Middleware\Exception\FileNotFoundException;
 use Wwwision\PrivateResources\Http\FileServeStrategy\FileServeStrategyInterface;
-use Neos\Neos\Controller\Backend\BackendController;
+use Neos\Neos\Controller\Frontend\NodeController;
 
 
 /**
@@ -165,7 +165,7 @@ class ProtectedResourceMiddleware implements MiddlewareInterface
             return;
         }
         $actionRequest = ActionRequest::fromHttpRequest($httpRequest);
-        $actionRequest->setControllerObjectName(BackendController::class);
+        $actionRequest->setControllerObjectName(NodeController::class);
         $this->securityContext->setRequest($actionRequest);
         if (isset($tokenData['privilegedRole'])) {
             if ($this->securityContext->hasRole($tokenData['privilegedRole'])) {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "A Flow package that allows for protecting persistent resources from unauthorized access",
     "license": "MIT",
     "require": {
-        "neos/flow": "^7.0",
+        "neos/flow": "^7.0 || ^8.0",
         "guzzlehttp/psr7": "^1.6"
     },
     "autoload": {


### PR DESCRIPTION
Hi Bastian,

we ran into the following issue when building the Neos Demo Site, where we need to protect resources uploaded by Editors to be seen and/or distributed:
When adding a privilegedRole, the user could not see his uploaded assets.
Only when we added a controller to the request, the authentication works.
Using the NodeController should work for both frontend and backend authentications.

Hope this is a feasible solution :)

Best
Stefan